### PR TITLE
fix: leaderboard scroll issue - only cards scroll now

### DIFF
--- a/app/components/dashboard-components/leaderboard.tsx
+++ b/app/components/dashboard-components/leaderboard.tsx
@@ -6,7 +6,7 @@ import Projects from "./projects";
 import Rowcards from "./rowcards";
 import { ScrollArea } from "@/app/components/ui/scroll-area";
 import useLeaderboardStore from "@/app/useLeaderboardStore";
-import { FaSort, FaSortUp, FaSortDown } from "react-icons/fa"; // Import sorting icons
+import { FaSort, FaSortUp, FaSortDown } from "react-icons/fa";
 
 export type TUserData = {
   fullName: string;
@@ -97,44 +97,47 @@ const Leaderboard = () => {
     );
   };
 
-
   return (
-    <Card className="bg-transparent border-none px-1 md:px-8 rounded-2xl z-50 w-full">
-      <Tabs defaultValue="leaderboard" className="w-full">
+    <Card className="bg-transparent border-none px-1 md:px-8 rounded-2xl z-50 w-full h-full">
+      <Tabs defaultValue="leaderboard" className="w-full h-full">
         <TabsList className="flex flex-row justify-between bg-[#1d1e3a] text-sm sm:text-base text-white h-10 w-full">
           <TabsTrigger className="w-full" value="leaderboard">Leaderboard</TabsTrigger>
           <TabsTrigger className="w-full" value="projects">Projects</TabsTrigger>
         </TabsList>
-        <TabsContent value="leaderboard">
-          <CardHeader className="font-bold text-3xl sm:text-6xl pt-2 sm:pt-4 pb-1 sm:pb-2 px-2 sm:px-4 text-[#3abef9]">
-            Leaderboard
-          </CardHeader>
-          <CardDescription className="px-2 sm:px-4 pb-2 sm:pb-4 text-[#c8c7cc] text-sm sm:text-base">
-            Refresh the page to see real-time leaderboard updates.
-          </CardDescription>
-          <div className="flex bg-[#1d1b2e] mx-1 sm:mx-2 p-2 sm:p-4 text-white sm:font-semibold rounded-lg">
-            <div className="text-xs sm:text-base w-[10%] text-left">Rank</div>
-            <div className="text-xs sm:text-base w-[70%] text-left pl-4 sm:pl-16">Name</div>
-            <div className="hidden min-[769px]:block text-sm sm:text-base w-[23%] text-center">
-              <button
-                onClick={() => sortLeaderboard("PRs")}
-                className="flex items-center justify-center gap-2 hover:text-[#3abef9] transition-colors duration-200"
-              >
-                PR Merged
-                {getSortIcon("PRs")}
-              </button>
-            </div>
-            <div className="text-xs sm:text-base w-[20%] sm:w-[13%] text-right">
-              <button
-                onClick={() => sortLeaderboard("Bounty")}
-                className="flex items-center justify-center gap-2 hover:text-[#3abef9] transition-colors duration-200"
-              >
-                Bounties
-                {getSortIcon("Bounty")}
-              </button>
+
+        <TabsContent value="leaderboard" className="flex flex-col h-full">
+          <div>
+            <CardHeader className="font-bold text-3xl sm:text-6xl pt-2 sm:pt-4 pb-1 sm:pb-2 px-2 sm:px-4 text-[#3abef9]">
+              Leaderboard
+            </CardHeader>
+            <CardDescription className="px-2 sm:px-4 pb-2 sm:pb-4 text-[#c8c7cc] text-sm sm:text-base">
+              Refresh the page to see real-time leaderboard updates.
+            </CardDescription>
+            <div className="flex bg-[#1d1b2e] mx-1 sm:mx-2 p-2 sm:p-4 text-white sm:font-semibold rounded-lg">
+              <div className="text-xs sm:text-base w-[10%] text-left">Rank</div>
+              <div className="text-xs sm:text-base w-[70%] text-left pl-4 sm:pl-16">Name</div>
+              <div className="hidden min-[769px]:block text-sm sm:text-base w-[23%] text-center">
+                <button
+                  onClick={() => sortLeaderboard("PRs")}
+                  className="flex items-center justify-center gap-2 hover:text-[#3abef9] transition-colors duration-200"
+                >
+                  PR Merged
+                  {getSortIcon("PRs")}
+                </button>
+              </div>
+              <div className="text-xs sm:text-base w-[20%] sm:w-[13%] text-right">
+                <button
+                  onClick={() => sortLeaderboard("Bounty")}
+                  className="flex items-center justify-center gap-2 hover:text-[#3abef9] transition-colors duration-200"
+                >
+                  Bounties
+                  {getSortIcon("Bounty")}
+                </button>
+              </div>
             </div>
           </div>
-          <ScrollArea className="max-h-[60vh] sm:max-h-[75vh] overflow-y-auto overflow-x-hidden relative">
+
+          <ScrollArea className="flex-1 overflow-y-auto">
             {leaderboardData.length === 0 ? (
               <div className="text-center text-2xl text-[#c8c7cc] p-4">
                 Loading Leaderboard...


### PR DESCRIPTION
@IAmRiteshKoushik , i fixed the issue where the whole leaderboard was scrolling instead of just the cards. Now, the header stays fixed, and only the cards section scrolls properly.  

changes I made:  
1.) made the parent container take up the full height.  
2.) adjusted the layout so the scrollable area fills the remaining space.  
3.) wrapped the header in a div to keep it fixed.  
4.) removed the fixed height classes that were messing things up.  

now, the scrolling works as expected.